### PR TITLE
fix: sanitize rpc query

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -288,6 +288,8 @@ export default class Surreal extends Emitter {
 	}
 
 	query(query, vars) {
+		query = query.replaceAll(/\n/g, " ");
+
 		let id = guid();
 		return this.wait().then( () => {
 			return new Promise( (resolve, reject) => {


### PR DESCRIPTION
Replacing `\n` with spaces for `query()` method.

_(I'm not sure that it's not a workaround-ish however.)_

Closes #1